### PR TITLE
Show headers in card switch

### DIFF
--- a/src/cardMarkup.ts
+++ b/src/cardMarkup.ts
@@ -111,11 +111,14 @@ export function formatBodyForCard(
 
 	if (endOfEventMarkerIndex > 0) body = body.slice(0, endOfEventMarkerIndex);
 	// Remove external image links
+        body = body.replace(/!\[.*\]\(.*\)/gi, "");
+        // Remove tags
+        if ( settings.showNoteHeadersInCardBody )
+            body = body.replace(/#[a-zA-Z\d-_/]*/gi, "");
+        else
+            body = body.replace(/#.*/gi, ""); // remove markup headers
 	return (
-		body
-			.replace(/!\[.*\]\(.*\)/gi, "")
-			// Remove tags
-			.replace(/#[a-zA-Z\d-_/]*/gi, "")
+		body			
 			// Remove internal images ![[Pasted image 20230418232101.png]]
 			.replace(/!\[\[.*\]\]/gi, "")
 			// Remove other timelines to avoid circular dependencies!

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,7 +42,7 @@
       "inlineEventEndOfBodyMarker": "End of event body token",
       "dateParserGroupPriority": "Date parser group priority",
       "dateParserRegex": "Date parser regex",
-      "fantasyCalendarPresetKeys": "Use fantady calendar keys",
+      "fantasyCalendarPresetKeys": "Use fantasy calendar keys",
       "metadataKeyEventBodyOverride": "Event body override",
       "metadataKeyEventTimelineTag": "Event timelines tags",
       "metadataKeyEventEndDate": "Event end key",
@@ -74,7 +74,8 @@
       "fantasyCalendarSpanEvents": {
         "text": "Look for {link}",
         "link": "Span Events"
-      }
+      },
+      "showNoteHeadersInCardBody": "Check to include header text from note body in card data"
     },
     "button": {
       "resetToDefault": "Reset to default",
@@ -112,7 +113,8 @@
         "conditionsAreExclusive": "When checked only one condition need to be true for the format to apply. If it's unchecked all conditions need to be true.",
         "format": "Use `{value}` to include the formated token in the template."
       },
-      "fantasyCalendarSpanEvents": "Allow the plugin to look for span events inside the notes, this have a performance impact but furthers the compatibility with fantasy calendar"
+      "fantasyCalendarSpanEvents": "Allow the plugin to look for span events inside the notes, this have a performance impact but furthers the compatibility with fantasy calendar",
+      "showNoteHeadersInCardBody": "Check to include header text from note body in card data"                 
     },
     "linkValue": {
       "lookForInlineEventsInNotes": "https://github.com/April-Gras/obsidian-auto-timelines#in-line-events",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -36,6 +36,7 @@ export const SETTINGS_DEFAULT = {
 	lookForInlineEventsInNotes: true,
 	lookForTagsForTimeline: false,
 	stylizeDateInline: false,
+        showNoteHeadersInCardBody: true,
 	// number
 	bodyFontSize: -1,
 	dateFontSize: -1,

--- a/src/views/VSettings.vue
+++ b/src/views/VSettings.vue
@@ -73,6 +73,7 @@ const checkboxKeys: readonly (keyof PickByType<
 	"lookForTagsForTimeline",
 	"applyAdditonalConditionFormatting",
 	"stylizeDateInline",
+        "showNoteHeadersInCardBody",
 ];
 
 const fontSizeOverrides: readonly (keyof PickByType<

--- a/tests/cardMarkup.test.ts
+++ b/tests/cardMarkup.test.ts
@@ -82,6 +82,32 @@ describe.concurrent("Card Markup", () => {
 		).not.toContain("body data");
 	});
 
+        test("[formatBodyForCard] - showNoteHeadersInCardBody True", () => {
+		const bodyMock = `Some sample ## Header Title\n body data`;
+		const timelineTextMock = "\n```aat-vertical\nother timeline\n```";
+
+		expect(
+			// Add fake note metadata block
+			formatBodyForCard(
+				SETTINGS_DEFAULT,
+				`---\n---\n${bodyMock}${timelineTextMock}`
+			)
+		).toContain("Header Title");
+	});
+        
+        test("[formatBodyForCard] - showNoteHeadersInCardBody False", () => {
+		const bodyMock = `Some sample ## Header Title\n body data`;
+		const timelineTextMock = "\n```aat-vertical\nother timeline\n```";
+                SETTINGS_DEFAULT.showNoteHeadersInCardBody = false;
+		expect(
+			// Add fake note metadata block                        
+			formatBodyForCard(
+				SETTINGS_DEFAULT,
+				`---\n---\n${bodyMock}${timelineTextMock}`
+			)
+		).not.toContain("Header Title");
+	});
+
 	test("[createCardFromBuiltContext] - font overrides", () => {
 		const context = mockMarkdownCodeBlockTimelineProcessingContext();
 		const cardContent = mockCardContext();


### PR DESCRIPTION
Added the ability to switch off note body Header text from appearing in Timeline Cards