### PR TITLE
Fix #188

### DIFF
--- a/src/components/VIconButton.vue
+++ b/src/components/VIconButton.vue
@@ -25,7 +25,7 @@ defineSlots<{
 	</VButton>
 </template>
 
-<style lang="scss">
+<style scoped lang="scss">
 button.iconButton {
 	position: relative;
 	display: flex;

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ export default class AprilsAutomaticTimelinesPlugin extends Plugin {
 	 */
 	async onload() {
 		await this.loadSettings();
+
 		this.registerEditorSuggest(new TimelineMarkdownSuggester(this));
 		this.registerMarkdownCodeBlockProcessor(
 			verticalTimelineToken,

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,6 @@ export default class AprilsAutomaticTimelinesPlugin extends Plugin {
 	 */
 	async onload() {
 		await this.loadSettings();
-
 		this.registerEditorSuggest(new TimelineMarkdownSuggester(this));
 		this.registerMarkdownCodeBlockProcessor(
 			verticalTimelineToken,


### PR DESCRIPTION
Fixes #188

Literally just added the word `scoped` to the component that caused the css conflict. Looks like it was just forgotten, since every other component has it's style tags scoped.